### PR TITLE
Laravel 5.4 Support

### DIFF
--- a/src/Eloquent/Query/Builder.php
+++ b/src/Eloquent/Query/Builder.php
@@ -24,7 +24,7 @@ class Builder extends QueryBuilder
      *
      * @var array
      */
-    protected $bindings = [
+    public $bindings = [
         'select' => [],
         'join' => [],
         'where' => [],

--- a/src/SphinxConnection.php
+++ b/src/SphinxConnection.php
@@ -75,32 +75,6 @@ class SphinxConnection extends MySqlConnection
     }
 
     /**
-     * Run a select statement against the database.
-     *
-     * @param  string $query
-     * @param  array $bindings
-     * @param  bool $useReadPdo
-     * @return array
-     */
-    public function select($query, $bindings = [], $useReadPdo = true)
-    {
-        return $this->run($query, $bindings, function ($me, $query, $bindings) use ($useReadPdo) {
-            if ($me->pretending()) {
-                return [];
-            }
-
-            // For select statements, we'll simply execute the query and return an array
-            // of the database result set. Each element in the array will be a single
-            // row from the database table, and will either be an array or objects.
-            $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
-
-            $statement->execute($me->prepareBindings($bindings));
-
-            return $statement->fetchAll($me->getFetchMode());
-        });
-    }
-
-    /**
      * Get the default query grammar instance.
      *
      * @return \Fobia\Database\SphinxConnection\Eloquent\Query\Grammar


### PR DESCRIPTION
These changes were needed in order to get this library to boot and do a simple select with Laravel 5.4's database framework.  I do not know if these are the *only* changes needed, just that they are required for me to be able to use the library at all.  At least the `public $bindings` change should be backward compatible with 5.3, I think.