### PR TITLE
Removed concatenation of "AND" if where is empty

### DIFF
--- a/src/Eloquent/Query/Grammar.php
+++ b/src/Eloquent/Query/Grammar.php
@@ -225,7 +225,7 @@ class Grammar extends BaseGrammar
         $where = parent::compileWheres($query);
         // If SphinxQL generator
         if (!empty($query->match)) {
-            $where = ' AND ' . substr($where, 5);
+            $where = (empty($where) ? '' : ' AND ') . substr($where, 5);
         }
         return $where;
     }


### PR DESCRIPTION
When updating to Laravel 5.5 a query with no wheres still calls compileWheres whereas an trailing "AND" is concatenated and causes a syntax error.

Example error:
```SQLSTATE[42000]: Syntax error or access violation: 1064 sphinxql: syntax error, unexpected ORDER near 'order by level asc LIMIT 0, 100' (SQL: select id FROM table_name WHERE MATCH('(query*)') AND order by level asc LIMIT 0, 100)```

Caused by:
```
\DB::connection('sphinx')
    ->table('table_name')
    ->match('*', 'query*')
    ->orderBy('level')
    ->limit(100)
    ->pluck('id');
```

This commit fixes this error by checking if the `$where` variable is empty or not.